### PR TITLE
footer with grid

### DIFF
--- a/_src/assets/scss/layout/_footer.scss
+++ b/_src/assets/scss/layout/_footer.scss
@@ -59,11 +59,12 @@
     
     .footer__menu--list {
         text-align: right;
-        margin: 0 45px 80px;
+        margin: 0 45px 70px;
         font-size: 14px;
-        line-height: 30px; 
+        line-height: 30px;
+        padding-top: 20px; 
     }
-    
+
     .logo {
         width: auto;
         margin: -120px 45px 0;

--- a/_src/assets/scss/layout/_footer.scss
+++ b/_src/assets/scss/layout/_footer.scss
@@ -1,36 +1,31 @@
 /*FOOTER*/
 .footer {
-    width: 100vw;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr 1fr;
+    text-align: center;
     border-top: solid grey 1px;
     font-family: 'Open Sans', sans-serif;
     font-size: 14px;
-    box-sizing: border-box;
 }
 
 .copyright {
-    
-    margin: 30px 74px 0 74px;
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
     color: #b8b8b9;
     font-size: 14px;
     font-family: 'Open Sans', sans-serif;
 }
 
 .footer__menu--list {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
     text-transform: uppercase;
-    display: flex;
-    flex-direction: column;
     font-size: 14px;
-    margin: 20px 103px;
     padding: 0;
-    width:  114px;
-    height: 60px;
     line-height: 20px;
-    list-style-type: none;
-    justify-content: center;
-    align-items: center; 
+    list-style-type: none; 
+    text-align: center;
 }
 
 .footer__menu--list a {
@@ -39,10 +34,8 @@
 }
 
 .logo {
-    width: auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    grid-column: 1 / 2;
+    grid-row: 3 / 4;
 }
 
 .logo-adalab {
@@ -51,29 +44,30 @@
 }
 
 @media all and (min-width: 768px) {
-    .copyright {
-        display: flex;
-        align-self: flex-start; 
+    .footer {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr;   
+    }
+
+    .copyright { 
+        text-align: left;
         width: auto;
         margin: 0 45px;
         padding: 20px 0;     
     }
-    .footer__menu {
-        width: auto;
-        display: flex;
-        align-self: flex-end;   
-    }
+    
     .footer__menu--list {
-        align-items: flex-end;
+        text-align: right;
         margin: 0 45px 80px;
         font-size: 14px;
         line-height: 30px; 
     }
+    
     .logo {
         width: auto;
         margin: -120px 45px 0;
-        display: flex;
-        align-self: flex-start;
+        text-align: left;
         padding: 0;
     }
 }


### PR DESCRIPTION
He convertido el footer en un grid. En la versión móvil está compuesto de una columna con tres filas. En las versiones table y ordenador la rejilla está formada por dos columnas y una fila. De esta manera se distribuye el contenido de la misma forma que antes pero con un css más sencillo (se elimina todos los display: flex).